### PR TITLE
fix(basic_auth): Fixed logic causing basic_auth_enabled to always evaluate to true 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  enable_basic_auth = var.username != null && var.password != null || var.username != "" && var.password != ""
+  enable_basic_auth = (var.username != null && var.password != null) && (var.username != "" && var.password != "")
   tags              = merge(var.tags, { CreatedWith = "Terraform" })
 }
 


### PR DESCRIPTION
## Description

Previously the example provided [here](https://github.com/JetBrains/terraform-aws-amplify/blob/main/examples/standard/main.tf) did not actually work since enable_basic_auth would always evaluate to true. This pr corrects the logic for the variable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## Checklist:

- [x] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [x] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [x] I have tested my changes on a live Kubernetes cluster.

## Additional Information

Any additional information or context to provide reviewers of this pull request.

## Screenshots

If you have added any visual changes, please add screenshots here to demonstrate them.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
